### PR TITLE
Add Robbinsdale Area Schools (rdale.org)

### DIFF
--- a/lib/domains/org/rdale.txt
+++ b/lib/domains/org/rdale.txt
@@ -1,0 +1,1 @@
+Robbinsdale Area Schools


### PR DESCRIPTION
Adds a whole district which uses the same domain ([rdale.org](https://rdale.org)) for their elementary schools (uses scratch.mit.edu and code.org to teach basic programming concepts without a text editor), middle schools (expands on scratch.mit.edu and uses Python), **high schools (has full-fledged computer science classes).**